### PR TITLE
fix: footer social images overflowing in small viewports

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="astro/client" />
-/// <reference path="content.d.ts" />

--- a/src/components/SocialLink.astro
+++ b/src/components/SocialLink.astro
@@ -4,18 +4,21 @@ import { Image } from "astro:assets";
 
 interface Props {
 	alt: string;
+	class?: string;
 	href: string;
 	inverted?: boolean;
 	src: ImageMetadata;
 }
+
+const { alt, class: className, inverted, href, src } = Astro.props;
 ---
 
 <a
-	class:list={["social-link", Astro.props.inverted && "social-link-inverted"]}
-	href={Astro.props.href}
+	class:list={["social-link", inverted && "social-link-inverted"]}
+	href={href}
 	target="_blank"
 >
-	<Image alt={Astro.props.alt} class="social-image" src={Astro.props.src} />
+	<Image alt={alt} class="social-image" src={src} />
 </a>
 
 <style>

--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -5,12 +5,23 @@ import SocialLink from "./SocialLink.astro";
 ---
 
 <div class="socials">
-	{socials.map((social) => <SocialLink {...social} />)}
+	{socials.map((social) => <SocialLink class="social-link" {...social} />)}
 </div>
 
 <style>
 	.socials {
 		display: flex;
-		gap: 1rem;
+		flex-wrap: wrap;
+		gap: 2rem;
+		margin-top: 2rem;
+		max-width: 15rem;
+	}
+
+	@media (width >= 490px) {
+		.socials {
+			gap: 1rem;
+			margin-top: 0;
+			max-width: none;
+		}
 	}
 </style>


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #30
- [x] That issue was marked as [`status: accepting prs`](https://github.com/SquiggleTools/SquiggleConf2025/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/SquiggleTools/SquiggleConf2025/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adjusts the images to become a bigger spaced grid(-ish) below 490px.

💖