### PR TITLE
Remove unwanted space before period after emphasized links in About Us

### DIFF
--- a/src/components/AboutUs.astro
+++ b/src/components/AboutUs.astro
@@ -41,8 +41,8 @@ import BodyText from "./BodyText.astro";
 		<EmphasizedText
 			><a href="https://michigantypescript.com" target="_blank"
 				>Michigan TypeScript</a
-			></EmphasizedText
-		>.
+			>.</EmphasizedText
+		>
 	</BodyText>
 
 	<BodyText class="about-us-body-text">
@@ -60,8 +60,8 @@ import BodyText from "./BodyText.astro";
 
 	<BodyText class="about-us-body-text">
 		Learn more about us on <EmphasizedText
-			><a href="/about">About</a></EmphasizedText
-		>.</BodyText
+			><a href="/about">About</a>.</EmphasizedText
+		></BodyText
 	>
 </ImagesAndTextTwoColumn>
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to squiggleconf.com! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Steps in [CONTRIBUTING.md](https://github.com/SquiggleTools/SquiggleConf.com/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes #39 

### This PR fixes a spacing issue in the About Us section where there was an unwanted space between emphasized link text and the period at the end of the sentence.

**Before :**

<img width="368" height="58" alt="Before Screenshot Typescript" src="https://github.com/user-attachments/assets/e4afdf57-9464-4b7d-97af-547b962a9d39" /> <br>

<img width="316" height="52" alt="Before Screenshot About" src="https://github.com/user-attachments/assets/6a609714-a66b-467a-bdd0-e5b1290e0604" />

**After:**

<img width="364" height="60" alt="After Screenshot Typescript" src="https://github.com/user-attachments/assets/52553fa8-a6a5-4594-a1e8-fcb0375fb2cf" /> <br>

<img width="306" height="46" alt="After Screenshot About" src="https://github.com/user-attachments/assets/35770ea2-f53d-4750-8aa7-d2b2f54bc544" />

